### PR TITLE
Supports overriding the default paths required for custom installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -139,4 +139,4 @@ requirement
 gen_config_file
 install
 echo "crowdsec-openresty-bouncer installed successfully"
-echo "Run 'sudo systemctl restart openresty.service' to start openresty-bouncer"
+[ -z ${DOCKER} ] && echo "Run 'sudo systemctl restart openresty.service' to start openresty-bouncer"

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+echo "Starting Crowdsec Openresty Bouncer install"
 NGINX_CONF="crowdsec_openresty.conf"
 NGINX_CONF_DIR="/usr/local/openresty/nginx/conf/conf.d/"
 LIB_PATH="/usr/local/openresty/lualib/"
@@ -26,7 +26,7 @@ do
 		    DATA_PATH="${1#*=}"
 	    ;;
         --docker)
-		    DOCKER=1
+		    DOCKER="1"
 	    ;;
     esac
     shift
@@ -37,7 +37,7 @@ check_pkg_manager(){
         PKG="yum"
         PACKAGE_LIST="yum list installed"
         SSL_CERTS_PATH="/etc/ssl/certs/ca-bundle.crt"
-    elif cat /etc/system-release | grep -q "Amazon Linux release 2 (Karoo)"; then
+    elif grep -q "Amazon Linux release 2 (Karoo)" < /etc/system-release ; then
         PKG="yum"
         PACKAGE_LIST="yum list installed"
         SSL_CERTS_PATH="/etc/ssl/certs/ca-bundle.crt"
@@ -58,33 +58,51 @@ requirement() {
 }
 
 gen_config_file() {
-    if [ -z ${DOCKER} ]; then
-        SUFFIX=`tr -dc A-Za-z0-9 </dev/urandom | head -c 8`
-        API_KEY=`cscli bouncers add crowdsec-openresty-bouncer-${SUFFIX} -o raw`
-        echo "New API key generated to be used in '${CONFIG_PATH}/crowdsec-openresty-bouncer.conf'"
+    #Don't overwrite the existing file
+    if [ ! -f "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf" ]; then
+        if [ -z ${DOCKER} ]; then
+            SUFFIX=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 8)
+            API_KEY=$(cscli bouncers add "crowdsec-openresty-bouncer-${SUFFIX}" -o raw) 
+            API_KEY=${API_KEY} CROWDSEC_LAPI_URL="http://127.0.0.1:8080" envsubst < ./config/config_example.conf > "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf"
+            echo "New API key generated to be used in '${CONFIG_PATH}/crowdsec-openresty-bouncer.conf'"
+        else
+            #Docker doesn't support envsubst by default
+            API_KEY="1234567890abcdef"
+            cp config/config_example.conf "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf"
+            sed -i 's|API_KEY=.*|API_KEY='${API_KEY}'|' "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf"
+            sed -i 's|CROWDSEC_LAPI_URL=.*|CROWDSEC_LAPI_URL="http://127.0.0.1:8080"|' "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf"
+        fi
     else
-        API_KEY="1234567890abcdef"
+        #Patch the existing file with new parameters if the need to be added
+        echo "Patch crowdsec-openresty-bouncer.conf .." 
+        sed "s/=.*//g" "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf" > /tmp/crowdsec.conf.raw
+        sed "s/=.*//g" ./config/config_example.conf  > /tmp/config_example.conf.raw
+        if grep -vf /tmp/crowdsec.conf.raw /tmp/config_example.conf.raw ; then
+            grep -vf /tmp/crowdsec.conf.raw /tmp/config_example.conf.raw > /tmp/config_example.newvals
+            cp "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf" "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf.bak"
+            #Make sure we start on a new line.
+             echo "" >>"${CONFIG_PATH}/crowdsec-openresty-bouncer.conf"
+            grep -f /tmp/config_example.newvals /tmp/crowdsec/config/config_example.conf >> "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf"
+        fi
     fi
-    API_KEY=${API_KEY} CROWDSEC_LAPI_URL="http://127.0.0.1:8080" envsubst < ./config/config_example.conf > "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf"
-    # Not sure why couldn't patch the path useing envsubst
-    sed -i 's|/var/lib/crowdsec/lua|'${DATA_PATH}'|' "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf"
+    # Not sure why couldn't patch the path using envsubst
+    sed -i 's|/var/lib/crowdsec/lua|'"${DATA_PATH}"'|' "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf"
 }
 
 check_openresty_dependency() {
-    DEPENDENCY=(
-        "openresty-opm"
-    )
-    for dep in ${DEPENDENCY[@]};
+    DEPENDENCY=( \
+        "openresty-opm" \
+        )
+    for dep in "${DEPENDENCY[@]}";
     do
-        $PACKAGE_LIST | grep ${dep} > /dev/null
-        if [[ $? != 0 ]]; then
+        if ! $PACKAGE_LIST | grep "${dep}" > /dev/null; then
             echo "${dep} not found, do you want to install it (Y/n)? "
-            read answer
+            read -r answer
             if [[ ${answer} == "" ]]; then
                 answer="y"
             fi
             if [ "$answer" != "${answer#[Yy]}" ] ;then
-                "$PKG" install -y -qq ${dep} > /dev/null && echo "${dep} successfully installed"
+                "$PKG" install -y -qq "${dep}" > /dev/null && echo "${dep} successfully installed"
             else
                 echo "unable to continue without ${dep}. Exiting" && exit 1
             fi      
@@ -93,20 +111,20 @@ check_openresty_dependency() {
 }
 
 check_lua_dependency() {
-    DEPENDENCY=(
-        "pintsized/lua-resty-http"
+    DEPENDENCY=( \
+        "pintsized/lua-resty-http" \
     )
-    for dep in ${DEPENDENCY[@]};
+    for dep in "${DEPENDENCY[@]}";
     do
-        opm list | grep ${dep} > /dev/null
-        if [[ $? != 0 ]]; then
+        
+        if ! opm list | grep "${dep}" > /dev/null; then
             echo "${dep} not found, do you want to install it (Y/n)? "
-            read answer
+            read -r answer
             if [[ ${answer} == "" ]]; then
                 answer="y"
             fi
             if [ "$answer" != "${answer#[Yy]}" ] ;then
-                opm get ${dep} > /dev/null && echo "${dep} successfully installed"
+                opm get "${dep}" > /dev/null && echo "${dep} successfully installed"
             else
                 echo "unable to continue without ${dep}. Exiting" && exit 1
             fi      
@@ -116,23 +134,29 @@ check_lua_dependency() {
 
 
 install() {
-    mkdir -p ${DATA_PATH}/templates/
+    mkdir -p "${DATA_PATH}/templates/"
 
-    cp -r lua/lib/* ${LIB_PATH}/
-    cp templates/* ${DATA_PATH}/templates/
+    cp -r lua/lib/* "${LIB_PATH}/"
+    cp templates/* "${DATA_PATH}/templates/"
     #Patch the nginx config file
-    SSL_CERTS_PATH=${SSL_CERTS_PATH} envsubst < openresty/${NGINX_CONF} > "${NGINX_CONF_DIR}/${NGINX_CONF}"
-    sed -i 's|/etc/crowdsec/bouncers|'${CONFIG_PATH}'|' "${NGINX_CONF_DIR}/${NGINX_CONF}"
+    if [ -z ${DOCKER} ]; then
+        SSL_CERTS_PATH=${SSL_CERTS_PATH} envsubst < openresty/${NGINX_CONF} > "${NGINX_CONF_DIR}/${NGINX_CONF}"
+    else
+        cp openresty/${NGINX_CONF} "${NGINX_CONF_DIR}/${NGINX_CONF}"
+        # shellcheck disable=SC2016 #We need to change the actual variable here
+        sed -i 's|${SSL_CERTS_PATH}|'${SSL_CERTS_PATH}'|' "${NGINX_CONF_DIR}/${NGINX_CONF}"
+    fi
+    sed -i 's|/etc/crowdsec/bouncers|'"${CONFIG_PATH}"'|' "${NGINX_CONF_DIR}/${NGINX_CONF}"
+    #Some docker images like Nginx Proxy Manager has this defined already.
     [ -z ${DOCKER} ] || sed -i 's|resolver local=on ipv6=off;||' "${NGINX_CONF_DIR}/${NGINX_CONF}"
 }
 
 
-if ! [ $(id -u) = 0 ] && [ -z ${DOCKER} ]; then
-    log_err "Please run the install script as root or with sudo"
+if ! [ "$(id -u)" = 0 ] && [ -z ${DOCKER} ]; then
+    echo "Please run the install script as root or with sudo"
     exit 1
 fi
 
-#Fix paths
 [ -z ${DOCKER} ] && check_pkg_manager
 requirement
 [ -z ${DOCKER} ] && check_openresty_dependency
@@ -141,3 +165,4 @@ gen_config_file
 install
 echo "crowdsec-openresty-bouncer installed successfully"
 [ -z ${DOCKER} ] && echo "Run 'sudo systemctl restart openresty.service' to start openresty-bouncer"
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -123,6 +123,7 @@ install() {
     #Patch the nginx config file
     SSL_CERTS_PATH=${SSL_CERTS_PATH} envsubst < openresty/${NGINX_CONF} > "${NGINX_CONF_DIR}/${NGINX_CONF}"
     sed -i 's|/etc/crowdsec/bouncers|'${CONFIG_PATH}'|' "${NGINX_CONF_DIR}/${NGINX_CONF}"
+    [ -z ${DOCKER} ] || sed -i 's|resolver local=on ipv6=off;||' "${NGINX_CONF_DIR}/${NGINX_CONF}"
 }
 
 

--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ gen_config_file() {
             API_KEY=$(cscli bouncers add "crowdsec-openresty-bouncer-${SUFFIX}" -o raw) 
         fi
         API_KEY=${API_KEY} CROWDSEC_LAPI_URL="http://127.0.0.1:8080" envsubst < ./config/config_example.conf > "${CONFIG_PATH}/crowdsec-openresty-bouncer.conf"
-        echo "New API key generated to be used in '${CONFIG_PATH}/crowdsec-openresty-bouncer.conf'"
+        [ -n "${API_KEY}" ] && echo "New API key generated to be used in '${CONFIG_PATH}/crowdsec-openresty-bouncer.conf'"
     else
         #Patch the existing file with new parameters if the need to be added
         echo "Patch crowdsec-openresty-bouncer.conf .." 


### PR DESCRIPTION
Implements: https://github.com/crowdsecurity/cs-openresty-bouncer/issues/16

I have tested on my setup and works

This requires this as well for the Nginx Proxy Manager Integration https://github.com/NginxProxyManager/docker-nginx-full/pull/7
https://github.com/crowdsecurity/lua-cs-bouncer/pull/27

