### PR TITLE
fix bad substitution error in docker startup

### DIFF
--- a/docker/docker_start.sh
+++ b/docker/docker_start.sh
@@ -54,6 +54,7 @@ if [ "$CAPTCHA_EXPIRATION" != "" ]; then
     sed -i "s,CAPTCHA_EXPIRATION.*,CAPTCHA_EXPIRATION=$CAPTCHA_EXPIRATION," $CROWDSEC_BOUNCER_CONFIG
 fi
 
-if [ "${IS_LUALIB_IMAGE,,}" != "true" ]; then
+IS_LUALIB_IMAGE=$(echo $IS_LUALIB_IMAGE | tr A-Z a-z)
+if [ "$IS_LUALIB_IMAGE" != "true" ]; then
     exec /usr/local/openresty/bin/openresty -g "daemon off;"
 fi


### PR DESCRIPTION
This PR fixes an bad substitution error when running the container with the below command on Kubernetes. The error message was `/docker_start.sh: line 59: syntax error: bad substitution`. This PR changes the logic how the boolean will be converted in lower case.
```
extraInitContainers:
  - name: init-clone-crowdsec-bouncer
    image: crowdsecurity/lua-bouncer-plugin:v0.1.7
    imagePullPolicy: IfNotPresent
    envFrom:
      - secretRef:
          name: crowdsec-ingress-bouncer-api-key 
    env:
      - name: API_URL
        value: "http://crowdsec-service.crowdsec.svc.cluster.local:8080"
      - name: DISABLE_RUN
        value: "true"
      - name: BOUNCER_CONFIG
        value: "/crowdsec/crowdsec-bouncer.conf"
    command: ['sh', '-c', "sh /docker_start.sh; mkdir -p /lua_plugins/crowdsec/; cp /crowdsec/* /lua_plugins/crowdsec/"]
    volumeMounts:
    - name: crowdsec-bouncer-plugin
      mountPath: /lua_plugins
```