### PR TITLE
Allow the SSL_CERTS_PATH to be configurable in the install.sh file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN cp lua-cs-bouncer/config_example.conf /etc/crowdsec/bouncers/crowdsec-openre
 RUN rm -rf ./lua-cs-bouncer/
 COPY ./openresty /tmp
 RUN SSL_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt envsubst < /tmp/crowdsec_openresty.conf > /etc/nginx/conf.d/crowdsec_openresty.conf
+RUN sed -i '1 i\resolver local=on ipv6=off;' /etc/nginx/conf.d/crowdsec_openresty.conf
 COPY ./docker/docker_start.sh /
 
 ENTRYPOINT /bin/bash docker_start.sh

--- a/install.sh
+++ b/install.sh
@@ -157,8 +157,6 @@ install() {
     #Patch the nginx config file
     SSL_CERTS_PATH=${SSL_CERTS_PATH} envsubst < openresty/${NGINX_CONF} > "${NGINX_CONF_DIR}/${NGINX_CONF}"
     sed -i 's|/etc/crowdsec/bouncers|'"${CONFIG_PATH}"'|' "${NGINX_CONF_DIR}/${NGINX_CONF}"
-    #Some docker images like Nginx Proxy Manager has this defined already.
-    [ -z ${DOCKER} ] || sed -i 's|resolver local=on ipv6=off;||' "${NGINX_CONF_DIR}/${NGINX_CONF}"
 }
 
 

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,9 @@ do
         --DATA_PATH=*)
             DATA_PATH="${1#*=}"
         ;;
+        --SSL_CERTS_PATH=*)
+            SSL_CERTS_PATH="${1#*=}"
+        ;;
         -y|--yes)
             SILENT="true"
         ;;
@@ -149,7 +152,6 @@ check_lua_dependency() {
 
 install() {
     mkdir -p "${DATA_PATH}/templates/"
-
     cp -r lua/lib/* "${LIB_PATH}/"
     cp templates/* "${DATA_PATH}/templates/"
     #Patch the nginx config file
@@ -157,7 +159,6 @@ install() {
     sed -i 's|/etc/crowdsec/bouncers|'"${CONFIG_PATH}"'|' "${NGINX_CONF_DIR}/${NGINX_CONF}"
     #Some docker images like Nginx Proxy Manager has this defined already.
     [ -z ${DOCKER} ] || sed -i 's|resolver local=on ipv6=off;||' "${NGINX_CONF_DIR}/${NGINX_CONF}"
-    [ -z ${DOCKER} ] || sed -i '/lua_ssl_trusted_certificate.*/d' "${NGINX_CONF_DIR}/${NGINX_CONF}"
 }
 
 

--- a/openresty/crowdsec_openresty.conf
+++ b/openresty/crowdsec_openresty.conf
@@ -1,6 +1,5 @@
 lua_package_path '$prefix/../lualib/plugins/crowdsec/?.lua;;';
 lua_shared_dict crowdsec_cache 50m;
-resolver local=on ipv6=off;
 lua_ssl_trusted_certificate ${SSL_CERTS_PATH};
 
 init_by_lua_block {

--- a/openresty/crowdsec_openresty.conf
+++ b/openresty/crowdsec_openresty.conf
@@ -8,7 +8,11 @@ init_by_lua_block {
 		ngx.log(ngx.ERR, "[Crowdsec] " .. err)
 		error()
 	end
-	ngx.log(ngx.ALERT, "[Crowdsec] Initialisation done")
+	if ok == "Disabled" then
+		ngx.log(ngx.ALERT, "[Crowdsec] Bouncer Disabled")
+	else
+		ngx.log(ngx.ALERT, "[Crowdsec] Initialisation done")
+	end
 }
 
 access_by_lua_block {

--- a/openresty/crowdsec_openresty.conf
+++ b/openresty/crowdsec_openresty.conf
@@ -1,5 +1,6 @@
 lua_package_path '$prefix/../lualib/plugins/crowdsec/?.lua;;';
 lua_shared_dict crowdsec_cache 50m;
+resolver local=on ipv6=off;
 lua_ssl_trusted_certificate ${SSL_CERTS_PATH};
 init_by_lua_block {
 	cs = require "crowdsec"

--- a/openresty/crowdsec_openresty.conf
+++ b/openresty/crowdsec_openresty.conf
@@ -2,6 +2,7 @@ lua_package_path '$prefix/../lualib/plugins/crowdsec/?.lua;;';
 lua_shared_dict crowdsec_cache 50m;
 resolver local=on ipv6=off;
 lua_ssl_trusted_certificate ${SSL_CERTS_PATH};
+
 init_by_lua_block {
 	cs = require "crowdsec"
 	local ok, err = cs.init("/etc/crowdsec/bouncers/crowdsec-openresty-bouncer.conf", "crowdsec-openresty-bouncer/v0.1.10")


### PR DESCRIPTION
Fixes https://github.com/crowdsecurity/cs-openresty-bouncer/issues/27

This removes  lua_ssl_trusted_certificate through my testing everything still works as expected on both ssl and normal sites. 