### PR TITLE
Renamed config file and hard linked it into the nginx conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG BUILD_ENV=git
-FROM openresty/openresty:alpine-fat as with_deps
+FROM openresty/openresty:alpine-fat AS with_deps
 RUN luarocks install lua-resty-http
 
-FROM with_deps as git
+FROM with_deps AS git
 ARG BUILD_ENV=git
 RUN if [ "$BUILD_ENV" == "git" ]; then apk add --no-cache git; fi
 RUN if [ "$BUILD_ENV" == "git" ]; then git clone https://github.com/crowdsecurity/lua-cs-bouncer.git ; fi
 
-FROM with_deps as local
+FROM with_deps AS local
 RUN if [ "$BUILD_ENV" == "local" ]; then COPY ./lua-cs-bouncer/ lua-cs-bouncer; fi
 
 FROM ${BUILD_ENV}
@@ -17,8 +17,10 @@ RUN cp -R lua-cs-bouncer/templates/* /var/lib/crowdsec/lua/templates/
 RUN cp lua-cs-bouncer/config_example.conf /etc/crowdsec/bouncers/crowdsec-openresty-bouncer.conf
 RUN rm -rf ./lua-cs-bouncer/
 COPY ./openresty /tmp
-RUN SSL_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt envsubst '$SSL_CERTS_PATH' < /tmp/crowdsec_openresty.conf > /etc/nginx/conf.d/crowdsec_openresty.conf
-RUN sed -i '1 i\resolver local=on ipv6=off;' /etc/nginx/conf.d/crowdsec_openresty.conf
+RUN SSL_CERTS_PATH=/etc/ssl/certs/ca-certificates.crt envsubst '$SSL_CERTS_PATH' < /tmp/crowdsec_openresty.conf > /etc/crowdsec/bouncers/crowdsec_openresty_lua.conf
+RUN sed -i '1 i\resolver local=on ipv6=off;' /etc/crowdsec/bouncers/crowdsec_openresty_lua.conf
+RUN sed -i '/^http {/,/^}/!b;/^}/i\\n    include \/etc\/crowdsec\/bouncers\/crowdsec_openresty_lua.conf;' /usr/local/openresty/nginx/conf/nginx.conf
 COPY ./docker/docker_start.sh /
+
 
 ENTRYPOINT /bin/bash docker_start.sh


### PR DESCRIPTION
The reason is that likely we would want to put more conf files into `/etc/nginx/conf.d` , so if this folder is linked to a local folder the `crowdsec_openresty.conf` always got lost. Like this, it is much easier to use.  